### PR TITLE
Add functionality for HTTP Multipart Form data Request

### DIFF
--- a/capsa-it/src/main/kotlin/digital/capsa/it/runner/HttpMultipartFileEntity.kt
+++ b/capsa-it/src/main/kotlin/digital/capsa/it/runner/HttpMultipartFileEntity.kt
@@ -1,0 +1,31 @@
+package digital.capsa.it.runner
+
+
+import org.springframework.http.ContentDisposition
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+
+@Component
+class HttpMultipartFileEntity(
+    entityName: String,
+    fileName: String,
+    fileContent: ByteArray
+) : HttpEntity<Any>() {
+    var httpEntity: HttpEntity<Any>
+
+    init {
+        val contentDisposition: ContentDisposition = ContentDisposition
+            .builder(MediaType.MULTIPART_FORM_DATA.subtype)
+            .name(entityName)
+            .filename(fileName)
+            .build()
+
+        val fileMap: MultiValueMap<String, String> = LinkedMultiValueMap()
+        fileMap.add(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString())
+        httpEntity = HttpEntity<Any>(fileContent, fileMap)
+    }
+}


### PR DESCRIPTION
Example of usage:

1. Create the **HttpMultipartFileEntity** object

        val summaryReportFile = HttpMultipartFileEntity(
            entityName = "statementReportFiles",
            fileName = summaryReportFilename,
            fileContent = StatementMockGenerator.mockStatementReportFileContent()
        ).httpEntity

2. Push the created **HttpEntity** to the **HttpRequestBuilder** using **.withMultiPartFormData()**

       return HttpRequestBuilder(AbstractTestBase.objectMapper, "/requests/$requestFileName")
            .withTransformation(*transformations.toTypedArray())
            .withMultiPartFormData(*multiPartHttpEntities.toTypedArray())
            .send()


- Also consider:

![image](https://user-images.githubusercontent.com/97600045/163241547-72020cd3-90be-437d-b1a1-58847beb8c09.png)

- If you also want to send a object representation in form-data content type, please consider this example

      val statementData = HttpEntity<Any>(
            AbstractTestBase.objectMapper.writeValueAsString(statementDto),
            HttpHeaders().apply { contentType = MediaType.APPLICATION_JSON }
        )